### PR TITLE
test: unit test for updateBindings (Config.java)

### DIFF
--- a/src/main/java/com/jsoniter/spi/Config.java
+++ b/src/main/java/com/jsoniter/spi/Config.java
@@ -385,6 +385,11 @@ public class Config extends EmptyExtension {
         }
     }
 
+    // Added to be able to test the private method updateBindings()
+    public void updateBindings_helper(ClassDescriptor desc) {
+        updateBindings(desc);
+    }
+
     private void updateBindings(ClassDescriptor desc) {
         boolean globalOmitDefault = JsoniterSpi.getCurrentConfig().omitDefaultValue();
         for (Binding binding : desc.allBindings()) {

--- a/src/test/java/com/jsoniter/TestAnnotationJsonIgnore.java
+++ b/src/test/java/com/jsoniter/TestAnnotationJsonIgnore.java
@@ -68,6 +68,7 @@ public class TestAnnotationJsonIgnore extends TestCase {
     }
 
     public static class TestObject4 {
+        
         @JsonIgnore
         public String field1 = "Orange";
         private double field2 = 0.0;

--- a/src/test/java/com/jsoniter/TestAnnotationJsonIgnore.java
+++ b/src/test/java/com/jsoniter/TestAnnotationJsonIgnore.java
@@ -68,7 +68,7 @@ public class TestAnnotationJsonIgnore extends TestCase {
     }
 
     public static class TestObject4 {
-        
+
         @JsonIgnore
         public String field1 = "Orange";
         private double field2 = 0.0;
@@ -80,6 +80,9 @@ public class TestAnnotationJsonIgnore extends TestCase {
     }
 
     public void test_ignore_with_setter() throws IOException {
+        // contract: If a parameter has annotated tag @JsonIgnore
+        // it should not be possible to change the parameter using
+        // a the json iterator
         JsonIterator iter = JsonIterator.parse("{\"field1\": \"Apple\"}");
         TestObject4 t = iter.read(TestObject4.class);
         assertEquals("Orange",t.field1);

--- a/src/test/java/com/jsoniter/TestAnnotationJsonIgnore.java
+++ b/src/test/java/com/jsoniter/TestAnnotationJsonIgnore.java
@@ -1,9 +1,12 @@
 package com.jsoniter;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.jsoniter.annotation.JsonCreator;
 import com.jsoniter.annotation.JsonIgnore;
 import com.jsoniter.annotation.JsonProperty;
 import com.jsoniter.spi.DecodingMode;
+import jdk.nashorn.internal.objects.annotations.Getter;
+import jdk.nashorn.internal.objects.annotations.Setter;
 import junit.framework.TestCase;
 import org.junit.Test;
 
@@ -62,5 +65,22 @@ public class TestAnnotationJsonIgnore extends TestCase {
         JsonIterator iter = JsonIterator.parse("{\"field2\": \"test\"}");
         TestObject3 t = iter.read(TestObject3.class);
         assertNotNull(t.fieldXXX);
+    }
+
+    public static class TestObject4 {
+        @JsonIgnore
+        public String field1 = "Orange";
+        private double field2 = 0.0;
+
+        @Setter
+        public void setField2(double d) {
+            this.field2 = d;
+        }
+    }
+
+    public void test_ignore_with_setter() throws IOException {
+        JsonIterator iter = JsonIterator.parse("{\"field1\": \"Apple\"}");
+        TestObject4 t = iter.read(TestObject4.class);
+        assertEquals("Orange",t.field1);
     }
 }

--- a/src/test/java/com/jsoniter/spi/TestConfig.java
+++ b/src/test/java/com/jsoniter/spi/TestConfig.java
@@ -1,0 +1,59 @@
+package com.jsoniter.spi;
+
+import junit.framework.TestCase;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+
+import static org.junit.Assert.*;
+
+public class TestConfig extends TestCase {
+
+    public void test_Setter_True(){
+        // Contract: test the ClassDescriptor desc to have its setters as new String[0].
+        // Pass test only if the all setters are set to new String[0].
+
+        ClassInfo classInfo = new ClassInfo(int.class); // Try with Object.type
+
+        ClassDescriptor desc = ClassDescriptor.getDecodingClassDescriptor(classInfo, true);
+
+        Config conf = new Config(null, null);
+        for (Binding binding : desc.allBindings()) {
+            for (Binding setter : desc.setters) {
+                setter.name = binding.field.getName();
+            }
+        }
+
+        conf.updateBindings_helper(desc);
+
+        for (Binding setter : desc.setters) {
+            String[] s = new String[0];
+            assertArrayEquals(s, setter.fromNames);
+            assertArrayEquals(s, setter.toNames);
+        }
+    }
+
+    public void test_Setter_False(){
+        // Contract: test the ClassDescriptor desc to NOT have its setters as new String[0].
+        // Pass test only if the all setters are NOT set to new String[0].
+
+        ClassInfo classInfo = new ClassInfo(int.class); // Try with Object.type
+
+        ClassDescriptor desc = ClassDescriptor.getDecodingClassDescriptor(classInfo, true);
+
+        Config conf = new Config(null, null);
+        //for (Binding binding : desc.allBindings()) {
+            for (Binding setter : desc.setters) {
+                setter.name = "cow";
+            }
+        //}
+
+        conf.updateBindings_helper(desc);
+
+        for (Binding setter : desc.setters) {
+            String[] s = new String[0];
+            assertThat(s, IsNot.not(IsEqual.equalTo(setter.fromNames)));
+            assertThat(s, IsNot.not(IsEqual.equalTo(setter.toNames)));
+        }
+    }
+
+}

--- a/src/test/java/com/jsoniter/suite/AllTestCases.java
+++ b/src/test/java/com/jsoniter/suite/AllTestCases.java
@@ -10,6 +10,7 @@ import com.jsoniter.TestString;
 import com.jsoniter.any.TestList;
 import com.jsoniter.output.*;
 import com.jsoniter.output.TestInteger;
+import com.jsoniter.spi.TestConfig;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -53,6 +54,7 @@ import org.junit.runners.Suite;
         TestStreamBuffer.class,
         TestCollection.class,
         TestList.class,
-        TestAnnotationJsonObject.class})
+        TestAnnotationJsonObject.class,
+        com.jsoniter.spi.TestConfig.class})
 public abstract class AllTestCases {
 }


### PR DESCRIPTION
Fixes #33 

Note that we were unsuccessful in getting full coverage for the function as there's no easy way of unit testing it and by doing system/integration testing is fairly difficult because of the complexity of the project as a whole.